### PR TITLE
Fix wrong import in aot compat script.

### DIFF
--- a/cmsml/scripts/check_aot_compatibility.py
+++ b/cmsml/scripts/check_aot_compatibility.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import tabulate
 
 from cmsml.util import colored
-from cmsml.tensorflow.aot import OpsData, load_graph_def, get_graph_ops
+from cmsml.tensorflow.tools import load_graph_def
+from cmsml.tensorflow.aot import OpsData, get_graph_ops
 
 
 def check_aot_compatibility(


### PR DESCRIPTION
This PR contains a single line fix regarding a broken internal import of `load_graph_def` within the AOT compatibility test.