### PR TITLE
Fix provisioning imports in tf tools.

### DIFF
--- a/cmsml/tensorflow/__init__.py
+++ b/cmsml/tensorflow/__init__.py
@@ -5,15 +5,19 @@
 Classes, functions and tools for efficiently working with TensorFlow.
 """
 
-__all__ = ["import_tf", "save_frozen_graph", "load_frozen_graph", "write_graph_summary",
-"load_model", "load_graph_def","OpsData", "get_graph_ops"]
+__all__ = [
+    "import_tf", "save_frozen_graph", "save_graph", "load_frozen_graph", "load_graph",
+    "write_graph_summary", "load_model", "load_graph_def",
+    "OpsData", "get_graph_ops",
+]
 
 
 # provisioning imports
 from cmsml.tensorflow.tools import (
-    import_tf, save_frozen_graph, load_frozen_graph, write_graph_summary, load_model, load_graph_def
+    import_tf, save_frozen_graph, save_graph, load_frozen_graph, load_graph, write_graph_summary,
+    load_model, load_graph_def,
 )
 
 from cmsml.tensorflow.aot import (
-    OpsData, get_graph_ops
+    OpsData, get_graph_ops,
 )


### PR DESCRIPTION
This PR fixes some imports in the tensorflow tools.

Last time, we forgot to expose the deprecated `load_graph` and `save_graph` functions (that we renamed to `load_frozen_graph` and `save_frozen_graph`, respectively). This currently results in, e.g., 

```python
cmsml.tensorflow.save_graph(...)
```

not being accessible at all whereas we just wanted to deprecate them. This "hard cut" could lead to some complications downstream.

For consistency, a new release could be necessary.