### PR TITLE
Fix XLA flag encoding.

### DIFF
--- a/cmsml/scripts/compile_tf_graph.py
+++ b/cmsml/scripts/compile_tf_graph.py
@@ -153,13 +153,13 @@ def aot_compile(
         xla_flags_orig = env.get("XLA_FLAGS", "")
         if xla_flags_orig:
             xla_flags = [xla_flags_orig.rstrip(",")] + xla_flags
-        env["XLA_FLAGS"] = ",".join(map(str, xla_flags))
+        env["XLA_FLAGS"] = " ".join(map(str, xla_flags))
     if tf_xla_flags:
         tf_xla_flags = make_list(tf_xla_flags)
         tf_xla_flags_orig = env.get("TF_XLA_FLAGS", "")
         if tf_xla_flags_orig:
             tf_xla_flags = [tf_xla_flags_orig.rstrip(",")] + tf_xla_flags
-        env["TF_XLA_FLAGS"] = ",".join(map(str, tf_xla_flags))
+        env["TF_XLA_FLAGS"] = " ".join(map(str, tf_xla_flags))
 
     # prepare additional flags
     additional_flags_str = " ".join(make_list(additional_flags)) if additional_flags else ""


### PR DESCRIPTION
There has been a typo in the encoding of multiple `[TF_]XLA_FLAGS` in the environment variables for compiling aot models. Instead of using commas, the recommendation is to use spaces instead.

I guess this calls for another tag so that we can propagate this to cmsdist.

@Bogdan-Wiederspan @valsdav 