### PR TITLE
Python 3.12 image

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Build and deploy image 🐳
       uses: docker/build-push-action@v5
       with:
-        context: docker
+        context: .
         file: ${{ inputs.docker_file }}
         platforms: ${{ inputs.platforms }}
         push: ${{ inputs.push_image }}

--- a/.github/workflows/deploy_images.yml
+++ b/.github/workflows/deploy_images.yml
@@ -20,6 +20,7 @@ on:
           - py310
           - py311
           - py311-cuda
+          - py312
           - example
 
       platforms:
@@ -71,7 +72,7 @@ jobs:
           push_image: ${{ github.event.inputs.push_image == 'true' }}
 
   py39:
-    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py39') }}
+    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py39') || contains(github.event.inputs.specific_job, 'docs') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -166,8 +167,27 @@ jobs:
           tags: cmsml/cmsml:3.11-cuda
           push_image: ${{ github.event.inputs.push_image == 'true' }}
 
+  py312:
+    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py312') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Build and deploy image 🐳
+        uses: ./.github/actions/build-image
+        with:
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker_file: docker/Dockerfile_312
+          platforms: ${{ github.event.inputs.platforms }}
+          tags: cmsml/cmsml:3.12
+          push_image: ${{ github.event.inputs.push_image == 'true' }}
+
   docs:
-    if: ${{ github.event.inputs.push_image == 'true' && (github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'example')) }}
+    if: ${{ github.event.inputs.push_image == 'true' && (github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'docs')) }}
     needs: py39
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy_images.yml
+++ b/.github/workflows/deploy_images.yml
@@ -21,7 +21,7 @@ on:
           - py311
           - py311-cuda
           - py312
-          - example
+          - docs
 
       platforms:
         description: Platforms to build for
@@ -34,7 +34,7 @@ on:
 
 jobs:
   py37:
-    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py37') }}
+    if: ${{ github.event.inputs.specific_job == 'all' || github.event.inputs.specific_job == 'py37' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -53,7 +53,7 @@ jobs:
           push_image: ${{ github.event.inputs.push_image == 'true' }}
 
   py38:
-    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py38') }}
+    if: ${{ github.event.inputs.specific_job == 'all' || github.event.inputs.specific_job == 'py38' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -72,7 +72,7 @@ jobs:
           push_image: ${{ github.event.inputs.push_image == 'true' }}
 
   py39:
-    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py39') || contains(github.event.inputs.specific_job, 'docs') }}
+    if: ${{ github.event.inputs.specific_job == 'all' || github.event.inputs.specific_job == 'py39' || github.event.inputs.specific_job == 'docs' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -91,7 +91,7 @@ jobs:
           push_image: ${{ github.event.inputs.push_image == 'true' }}
 
   py39_base:
-    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py39') }}
+    if: ${{ github.event.inputs.specific_job == 'all' || github.event.inputs.specific_job == 'py39' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -110,7 +110,7 @@ jobs:
           push_image: ${{ github.event.inputs.push_image == 'true' }}
 
   py310:
-    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py310') }}
+    if: ${{ github.event.inputs.specific_job == 'all' || github.event.inputs.specific_job == 'py310' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -129,7 +129,7 @@ jobs:
           push_image: ${{ github.event.inputs.push_image == 'true' }}
 
   py311:
-    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py311') }}
+    if: ${{ github.event.inputs.specific_job == 'all' || github.event.inputs.specific_job == 'py311' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -148,7 +148,7 @@ jobs:
           push_image: ${{ github.event.inputs.push_image == 'true' }}
 
   py311-cuda:
-    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py311-cuda') }}
+    if: ${{ github.event.inputs.specific_job == 'all' || github.event.inputs.specific_job == 'py311-cuda' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -168,7 +168,7 @@ jobs:
           push_image: ${{ github.event.inputs.push_image == 'true' }}
 
   py312:
-    if: ${{ github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'py312') }}
+    if: ${{ github.event.inputs.specific_job == 'all' || github.event.inputs.specific_job == 'py312' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -187,7 +187,7 @@ jobs:
           push_image: ${{ github.event.inputs.push_image == 'true' }}
 
   docs:
-    if: ${{ github.event.inputs.push_image == 'true' && (github.event.inputs.specific_job == 'all' || contains(github.event.inputs.specific_job, 'docs')) }}
+    if: ${{ github.event.inputs.push_image == 'true' && (github.event.inputs.specific_job == 'all' || github.event.inputs.specific_job == 'docs') }}
     needs: py39
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -31,6 +31,7 @@ jobs:
           - {tag: "3.9", tf: "default"}
           - {tag: "3.10", tf: "default"}
           - {tag: "3.11", tf: "default"}
+          - {tag: "3.12", tf: "default"}
           # scan tf versions
           - {tag: "3.9_base", tf: "2.5.3"}
           - {tag: "3.9_base", tf: "2.6.5"}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ To use the cmsml package via docker, checkout our [DockerHub](https://hub.docker
 | `cmsml/cmsml:3.10`                                           |      3.10      | latest (~2.16.1) | latest (~2.3.0) |      ✘      |
 | `cmsml/cmsml:3.11`                                           |      3.11      | latest (~2.16.1) | latest (~2.3.0) |      ✘      |
 | `cmsml/cmsml:3.11-cuda`                                      |      3.11      | latest (~2.16.1) | latest (~2.3.0) |      ✔︎      |
+| `cmsml/cmsml:3.12`                                           |      3.12      | latest (~2.16.1) | latest (~2.3.0) |      ✘      |
 
 <!-- marker-after-docker -->
 
@@ -74,7 +75,7 @@ The tests can be triggered with
 pytest -n auto tests
 ```
 
-and in general, they should be run for Python 3.7 to 3.11.
+and in general, they should be run for Python 3.7 to 3.12.
 To run tests in a docker container, do
 
 ```shell

--- a/docker/Dockerfile_310
+++ b/docker/Dockerfile_310
@@ -8,7 +8,7 @@ RUN apt-get update; apt-get clean
 RUN apt-get install -y nano less htop git libhdf5-serial-dev; apt-get clean
 
 # python software stack
-RUN pip install --no-cache-dir --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir --upgrade ipython
 RUN pip install --no-cache-dir numpy
 RUN pip install --no-cache-dir scipy

--- a/docker/Dockerfile_310
+++ b/docker/Dockerfile_310
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir torch
 # install cmsml from master
 RUN git clone https://github.com/cms-ml/cmsml.git && \
     cd cmsml && \
-    pip install --no-cache-dir .[dev] && \
+    pip install --no-cache-dir --upgrade .[dev] && \
     cd .. && \
     rm -rf cmsml
 

--- a/docker/Dockerfile_310
+++ b/docker/Dockerfile_310
@@ -26,12 +26,9 @@ RUN pip install --no-cache-dir nvidia_smi
 RUN pip install --no-cache-dir py3nvml
 RUN pip install --no-cache-dir torch
 
-# install cmsml from master
-RUN git clone https://github.com/cms-ml/cmsml.git && \
-    cd cmsml && \
-    pip install --no-cache-dir --upgrade .[dev] && \
-    cd .. && \
-    rm -rf cmsml
+# copy and install
+COPY . /cmsml
+RUN pip install --no-cache-dir --upgrade /cmsml[dev] && rm -rf /cmsml
 
 # initial command
 CMD ["bash", "-i", "-l"]

--- a/docker/Dockerfile_311
+++ b/docker/Dockerfile_311
@@ -8,7 +8,7 @@ RUN apt-get update; apt-get clean
 RUN apt-get install -y nano less htop git libhdf5-serial-dev; apt-get clean
 
 # python software stack
-RUN pip install --no-cache-dir --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir --upgrade ipython
 RUN pip install --no-cache-dir numpy
 RUN pip install --no-cache-dir scipy

--- a/docker/Dockerfile_311
+++ b/docker/Dockerfile_311
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir torch
 # install cmsml from master
 RUN git clone https://github.com/cms-ml/cmsml.git && \
     cd cmsml && \
-    pip install --no-cache-dir .[dev] && \
+    pip install --no-cache-dir --upgrade .[dev] && \
     cd .. && \
     rm -rf cmsml
 

--- a/docker/Dockerfile_311
+++ b/docker/Dockerfile_311
@@ -26,12 +26,9 @@ RUN pip install --no-cache-dir nvidia_smi
 RUN pip install --no-cache-dir py3nvml
 RUN pip install --no-cache-dir torch
 
-# install cmsml from master
-RUN git clone https://github.com/cms-ml/cmsml.git && \
-    cd cmsml && \
-    pip install --no-cache-dir --upgrade .[dev] && \
-    cd .. && \
-    rm -rf cmsml
+# copy and install
+COPY . /cmsml
+RUN pip install --no-cache-dir --upgrade /cmsml[dev] && rm -rf /cmsml
 
 # initial command
 CMD ["bash", "-i", "-l"]

--- a/docker/Dockerfile_311_cuda
+++ b/docker/Dockerfile_311_cuda
@@ -5,26 +5,26 @@ WORKDIR /root
 
 # minimal software stack
 RUN apt-get update; apt-get clean
-RUN apt-get install -y nano less htop git; apt-get clean
+RUN apt-get install -y nano less htop git libhdf5-serial-dev; apt-get clean
 
 # python software stack
-RUN pip install --no-cache-dir --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir --upgrade ipython
-RUN pip install --no-cache-dir \
-    numpy \
-    scipy \
-    matplotlib \
-    pandas \
-    numexpr \
-    jupyterlab \
-    notebook \
-    scikit-learn \
-    scikit-optimize \
-    xgboost \
-    scinum \
-    nvidia_smi \
-    py3nvml \  
-    torch
+RUN pip install --no-cache-dir numpy
+RUN pip install --no-cache-dir scipy
+RUN pip install --no-cache-dir matplotlib
+RUN pip install --no-cache-dir pandas
+RUN pip install --no-cache-dir numexpr
+RUN pip install --no-cache-dir jupyterlab
+RUN pip install --no-cache-dir notebook
+RUN pip install --no-cache-dir scikit-learn
+RUN pip install --no-cache-dir scikit-optimize
+RUN pip install --no-cache-dir tensorflow
+RUN pip install --no-cache-dir xgboost
+RUN pip install --no-cache-dir scinum
+RUN pip install --no-cache-dir nvidia_smi
+RUN pip install --no-cache-dir py3nvml
+RUN pip install --no-cache-dir torch
 
 # install cmsml from master
 RUN git clone https://github.com/cms-ml/cmsml.git && \

--- a/docker/Dockerfile_311_cuda
+++ b/docker/Dockerfile_311_cuda
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir torch
 # install cmsml from master
 RUN git clone https://github.com/cms-ml/cmsml.git && \
     cd cmsml && \
-    pip install --no-cache-dir .[dev] && \
+    pip install --no-cache-dir --upgrade .[dev] && \
     cd .. && \
     rm -rf cmsml
 

--- a/docker/Dockerfile_311_cuda
+++ b/docker/Dockerfile_311_cuda
@@ -26,12 +26,9 @@ RUN pip install --no-cache-dir nvidia_smi
 RUN pip install --no-cache-dir py3nvml
 RUN pip install --no-cache-dir torch
 
-# install cmsml from master
-RUN git clone https://github.com/cms-ml/cmsml.git && \
-    cd cmsml && \
-    pip install --no-cache-dir --upgrade .[dev] && \
-    cd .. && \
-    rm -rf cmsml
+# copy and install
+COPY . /cmsml
+RUN pip install --no-cache-dir --upgrade /cmsml[dev] && rm -rf /cmsml
 
 # initial command
 CMD ["bash", "-i", "-l"]

--- a/docker/Dockerfile_312
+++ b/docker/Dockerfile_312
@@ -8,7 +8,7 @@ RUN apt-get update; apt-get clean
 RUN apt-get install -y nano less htop git libhdf5-serial-dev; apt-get clean
 
 # python software stack
-RUN pip install --no-cache-dir --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir --upgrade ipython
 RUN pip install --no-cache-dir numpy
 RUN pip install --no-cache-dir scipy

--- a/docker/Dockerfile_312
+++ b/docker/Dockerfile_312
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir torch
 # install cmsml from master
 RUN git clone https://github.com/cms-ml/cmsml.git && \
     cd cmsml && \
-    pip install --no-cache-dir .[dev] && \
+    pip install --no-cache-dir --upgrade .[dev] && \
     cd .. && \
     rm -rf cmsml
 

--- a/docker/Dockerfile_312
+++ b/docker/Dockerfile_312
@@ -26,12 +26,9 @@ RUN pip install --no-cache-dir nvidia_smi
 RUN pip install --no-cache-dir py3nvml
 RUN pip install --no-cache-dir torch
 
-# install cmsml from master
-RUN git clone https://github.com/cms-ml/cmsml.git && \
-    cd cmsml && \
-    pip install --no-cache-dir --upgrade .[dev] && \
-    cd .. && \
-    rm -rf cmsml
+# copy and install
+COPY . /cmsml
+RUN pip install --no-cache-dir --upgrade /cmsml[dev] && rm -rf /cmsml
 
 # initial command
 CMD ["bash", "-i", "-l"]

--- a/docker/Dockerfile_312
+++ b/docker/Dockerfile_312
@@ -1,0 +1,37 @@
+FROM python:3.12
+
+# set the workdir
+WORKDIR /root
+
+# minimal software stack
+RUN apt-get update; apt-get clean
+RUN apt-get install -y nano less htop git libhdf5-serial-dev; apt-get clean
+
+# python software stack
+RUN pip install --no-cache-dir --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade ipython
+RUN pip install --no-cache-dir numpy
+RUN pip install --no-cache-dir scipy
+RUN pip install --no-cache-dir matplotlib
+RUN pip install --no-cache-dir pandas
+RUN pip install --no-cache-dir numexpr
+RUN pip install --no-cache-dir jupyterlab
+RUN pip install --no-cache-dir notebook
+RUN pip install --no-cache-dir scikit-learn
+RUN pip install --no-cache-dir scikit-optimize
+RUN pip install --no-cache-dir tensorflow
+RUN pip install --no-cache-dir xgboost
+RUN pip install --no-cache-dir scinum
+RUN pip install --no-cache-dir nvidia_smi
+RUN pip install --no-cache-dir py3nvml
+RUN pip install --no-cache-dir torch
+
+# install cmsml from master
+RUN git clone https://github.com/cms-ml/cmsml.git && \
+    cd cmsml && \
+    pip install --no-cache-dir .[dev] && \
+    cd .. && \
+    rm -rf cmsml
+
+# initial command
+CMD ["bash", "-i", "-l"]

--- a/docker/Dockerfile_37
+++ b/docker/Dockerfile_37
@@ -8,7 +8,7 @@ RUN apt-get update; apt-get clean
 RUN apt-get install -y nano less htop git libhdf5-serial-dev; apt-get clean
 
 # python software stack
-RUN pip install --no-cache-dir --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir --upgrade ipython
 RUN pip install --no-cache-dir numpy
 RUN pip install --no-cache-dir scipy

--- a/docker/Dockerfile_37
+++ b/docker/Dockerfile_37
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir torch
 # install cmsml from master
 RUN git clone https://github.com/cms-ml/cmsml.git && \
     cd cmsml && \
-    pip install --no-cache-dir .[dev] && \
+    pip install --no-cache-dir --upgrade .[dev] && \
     cd .. && \
     rm -rf cmsml
 

--- a/docker/Dockerfile_37
+++ b/docker/Dockerfile_37
@@ -26,12 +26,9 @@ RUN pip install --no-cache-dir nvidia_smi
 RUN pip install --no-cache-dir py3nvml
 RUN pip install --no-cache-dir torch
 
-# install cmsml from master
-RUN git clone https://github.com/cms-ml/cmsml.git && \
-    cd cmsml && \
-    pip install --no-cache-dir --upgrade .[dev] && \
-    cd .. && \
-    rm -rf cmsml
+# copy and install
+COPY . /cmsml
+RUN pip install --no-cache-dir --upgrade /cmsml[dev] && rm -rf /cmsml
 
 # initial command
 CMD ["bash", "-i", "-l"]

--- a/docker/Dockerfile_38
+++ b/docker/Dockerfile_38
@@ -8,7 +8,7 @@ RUN apt-get update; apt-get clean
 RUN apt-get install -y nano less htop git libhdf5-serial-dev; apt-get clean
 
 # python software stack
-RUN pip install --no-cache-dir --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir --upgrade ipython
 RUN pip install --no-cache-dir numpy
 RUN pip install --no-cache-dir scipy

--- a/docker/Dockerfile_38
+++ b/docker/Dockerfile_38
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir torch
 # install cmsml from master
 RUN git clone https://github.com/cms-ml/cmsml.git && \
     cd cmsml && \
-    pip install --no-cache-dir .[dev] && \
+    pip install --no-cache-dir --upgrade .[dev] && \
     cd .. && \
     rm -rf cmsml
 

--- a/docker/Dockerfile_38
+++ b/docker/Dockerfile_38
@@ -26,12 +26,9 @@ RUN pip install --no-cache-dir nvidia_smi
 RUN pip install --no-cache-dir py3nvml
 RUN pip install --no-cache-dir torch
 
-# install cmsml from master
-RUN git clone https://github.com/cms-ml/cmsml.git && \
-    cd cmsml && \
-    pip install --no-cache-dir --upgrade .[dev] && \
-    cd .. && \
-    rm -rf cmsml
+# copy and install
+COPY . /cmsml
+RUN pip install --no-cache-dir --upgrade /cmsml[dev] && rm -rf /cmsml
 
 # initial command
 CMD ["bash", "-i", "-l"]

--- a/docker/Dockerfile_39
+++ b/docker/Dockerfile_39
@@ -8,7 +8,7 @@ RUN apt-get update; apt-get clean
 RUN apt-get install -y nano less htop git libhdf5-serial-dev; apt-get clean
 
 # python software stack
-RUN pip install --no-cache-dir --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir --upgrade ipython
 RUN pip install --no-cache-dir numpy
 RUN pip install --no-cache-dir scipy

--- a/docker/Dockerfile_39
+++ b/docker/Dockerfile_39
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir torch
 # install cmsml from master
 RUN git clone https://github.com/cms-ml/cmsml.git && \
     cd cmsml && \
-    pip install --no-cache-dir .[dev] && \
+    pip install --no-cache-dir --upgrade .[dev] && \
     cd .. && \
     rm -rf cmsml
 

--- a/docker/Dockerfile_39
+++ b/docker/Dockerfile_39
@@ -26,12 +26,9 @@ RUN pip install --no-cache-dir nvidia_smi
 RUN pip install --no-cache-dir py3nvml
 RUN pip install --no-cache-dir torch
 
-# install cmsml from master
-RUN git clone https://github.com/cms-ml/cmsml.git && \
-    cd cmsml && \
-    pip install --no-cache-dir --upgrade .[dev] && \
-    cd .. && \
-    rm -rf cmsml
+# copy and install
+COPY . /cmsml
+RUN pip install --no-cache-dir --upgrade /cmsml[dev] && rm -rf /cmsml
 
 # initial command
 CMD ["bash", "-i", "-l"]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,5 +2,5 @@ flake8~=7.0.0;python_version>="3.8"
 flake8~=5.0.0;python_version<"3.8"
 flake8-commas~=2.1.0
 flake8-quotes~=3.3.2
-pytest-cov~=5.0.0
-pytest-xdist~=3.4.0
+pytest-cov~=5.0.0;python_version>="3.8"
+pytest-xdist~=3.4.0;python_version>="3.8"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
-flake8~=7.0
+flake8~=7.0.0;python_version>="3.8"
+flake8~=5.0.0;python_version<"3.8"
 flake8-commas~=2.1.0
 flake8-quotes~=3.3.2
 pytest-cov~=5.0.0


### PR DESCRIPTION
This PR adds a python 3.12 image and fixes the build of the legacy 3.7 image.

Also, the way that cmsml is installed initially into the images is slightly changed.

- So far, the `master` branch of the repo was fetched and installed. This, however, leads to problems when actually developing new features on other branches.
- Now, the repository present on the host system is copied in the build process and installed as is.